### PR TITLE
fix(config): remove google analytics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -60,6 +60,3 @@ url = "https://bsky.app/profile/hghtwr.bsky.social/"
 
 [markup.goldmark.renderer]
 unsafe = true
-
-[params.googleTagManager]
-id = "G-8QE7N3YHJ3"


### PR DESCRIPTION
The google analytics tag manager code is used by jensrantil.github.com. Because of that, [1] is showing up in my Google Analytics stats. I assume this website has copied the source code from [2] (which is fine!).

[1] https://hghtwr.github.io/posts/kargo-filling-the-gap/
[2] https://github.com/JensRantil/jensrantil.github.io